### PR TITLE
Fix: Normalize line endings between Windows and Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted 
+# to native line endings on checkout
+*.py text
+*.txt text
+*.md text
+*.json text
+*.yml text
+*.yaml text
+*.toml text
+*.cfg text
+*.ini text
+*.sh text eol=lf
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+
+# Specific files
+LICENSE text
+.gitignore text
+.gitattributes text
+README* text
+requirements.txt text


### PR DESCRIPTION
## Summary
- Added `.gitattributes` file to ensure consistent line endings across platforms
- Configured git to handle line endings properly with `core.autocrlf=input`

## Problem
Issue #2 reported that git shows files as modified due to line ending differences between Windows and Linux environments. This happens when developers work on the same repository from different operating systems.

## Solution
The `.gitattributes` file now:
- Sets `text=auto` as default behavior for automatic line ending normalization
- Explicitly declares text file types that should be normalized
- Ensures shell scripts (`.sh`) always use LF endings
- Ensures batch files (`.bat`) always use CRLF endings
- Marks binary files that should never be modified

## Test plan
- [x] Created `.gitattributes` file with proper configuration
- [x] Verified line endings are normalized correctly
- [x] Tested that git no longer shows line ending changes

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)