### PR TITLE
Update model name in README.md to match assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ llm-benchmark/
 python run_benchmarks.py \
     --llm_url "http://localhost:8080" \
     --api_key "your-api-key" \
-    --model "your-model-name" \
+    --model "gbase-llama-33" \
     --use_long_context \
     --adaptive \
     --request_timeout 60
@@ -88,7 +88,7 @@ python run_benchmarks.py \
 python llm_benchmark.py \
     --llm_url "http://localhost:8080" \
     --api_key "your-api-key" \
-    --model "your-model-name" \
+    --model "gbase-llama-33" \
     --num_requests 100 \
     --concurrency 10 \
     --output_tokens 128 \


### PR DESCRIPTION
## Summary
- Updated model name from `your-model-name` to `gbase-llama-33` in README.md example commands
- This change ensures consistency with the model name shown in the benchmark result images

## Related Issue
Fixes #4

## Test Plan
- [x] Verified that the model name in README.md now matches the name shown in assets/20250423-095132.jpg
- [x] Documentation change only - no code changes required

🤖 Generated with [Claude Code](https://claude.ai/code)